### PR TITLE
Harry/nonce test fix

### DIFF
--- a/ptlshs/nonce_test.go
+++ b/ptlshs/nonce_test.go
@@ -38,8 +38,8 @@ func TestNonceCache(t *testing.T) {
 
 	t.Run("eviction", func(t *testing.T) {
 		var (
-			firstExpiration  = time.Now()
-			secondExpiration = firstExpiration.Add(5 * sweepEvery)
+			firstExpiration  = time.Now().Add(-5 * sweepEvery)
+			secondExpiration = time.Now().Add(5 * sweepEvery)
 		)
 
 		firstBatch, secondBatch := []nonce{}, []nonce{}
@@ -49,8 +49,6 @@ func TestNonceCache(t *testing.T) {
 		}
 
 		nc := newNonceCache(sweepEvery)
-		// Ensure the first batch will be expired.
-		nc.now = func() time.Time { return firstExpiration.Add(2 * sweepEvery) }
 		defer nc.close()
 
 		for i := 0; i < perBatch; i++ {


### PR DESCRIPTION
The nonce test has been a bit pesky in CI because it relies on timing.  Locally, this has always worked out just fine, but I guess the CI server is more prone to long pauses.  Or perhaps it's just that it's slower.  In any case, these changes minimize the dependency on proper timing, hopefully making the test more reliable.