### PR TITLE
Hot fix: allow writing data of arbitrary size during hijack

### DIFF
--- a/hijack.go
+++ b/hijack.go
@@ -164,7 +164,7 @@ func (dc *disguisedConn) Write(b []byte) (n int, err error) {
 	if !dc.inDisguise {
 		return dc.Conn.Write(b)
 	}
-	n, err = tlsutil.WriteRecord(dc.Conn, b, dc.state)
+	n, err = tlsutil.WriteRecords(dc.Conn, b, dc.state)
 	if err != nil {
 		err = fmt.Errorf("failed to wrap data in TLS record: %w", err)
 	}


### PR DESCRIPTION
Fixing a bug introduced by https://github.com/getlantern/tlsmasq/pull/12.  Just going to merge this in.

- [ x ] Do the tests pass? Consistently?
- [ x ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ x ] Can it be QA’d in staging or something like staging?
- [ x ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ x ] Do we know how we’re going to deploy this?
- [ x ] Are we clear on what the support and maintenance impact is?
- [ x ] Did you create new documentation? Is it accessible and in the right place?
- [ x ] Has existing documentation been updated?
- [ x ] Have you logged tickets for related technical debt with the label “techdebt”?