### PR TITLE
Upgrade CI to Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - add_ssh_keys:


### PR DESCRIPTION
This will break the tests in CI, but that's actually the point.  Go 1.16 seems to have exposed new test failures (see https://github.com/getlantern/tlsmasq/issues/22) and we want to ensure these are resolved.