### PR TITLE
Bug fix (test): should not hang on to write buffer

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -52,8 +52,10 @@ func (conn *bufferedConn) Write(b []byte) (n int, err error) {
 	if conn.closed {
 		return 0, io.ErrClosedPipe
 	}
-	conn.writes <- b
-	return len(b), nil
+	copyB := make([]byte, len(b))
+	n = copy(copyB, b)
+	conn.writes <- copyB
+	return
 }
 
 func (conn *bufferedConn) Close() error {


### PR DESCRIPTION
This is a pretty obvious bug, so I'm going to go ahead and merge it.